### PR TITLE
Release_2026_06_08

### DIFF
--- a/src/components/books/BookMetaEdit.vue
+++ b/src/components/books/BookMetaEdit.vue
@@ -54,7 +54,10 @@
                     <a class="btn btn-primary" style="margin-bottom: 5px;" v-if="(getDemoStatus == 'rebuild' || getDemoStatus == 'progress') && currentBook.demo_zip_narration_size >=23 && currentBook.demo_zip_narration" :disabled="getDemoStatus == 'progress'" :href="this.API_URL + 'export/' + this.currentBook._id + '/exportNarration'" target="_blank">Narration {{currentBook.demo_zip_narration_size | prettyBytes }}</a>
                   </template>
                   <hr>
-                  <div class="demo-book-link" v-if="currentBook.demo"><a :href="this.SERVER_URL + currentBook.demo" target="_blank">{{this.SERVER_URL + currentBook.demo}}</a> <br /><!-- <button class="btn btn-primary" v-if="getDemoStatus == 'rebuild' || getDemoStatus == 'progress'" :disabled="getDemoStatus == 'progress'" v-clipboard="() => this.SERVER_URL + currentBook.demo" >Copy Link</button>--> <button class="btn btn-primary" v-on:click="deactivateDemoLink()"> Deactivate</button></div>
+                  <div class="demo-book-link" v-if="currentBook.demo">
+                    <a :href="demoLink" target="_blank">Demo HTML link</a> <br />
+                    <button class="btn btn-primary" v-on:click="deactivateDemoLink()"> Deactivate</button>
+                  </div>
                   <div v-if="!currentBook.demo">Public Demo Book link has been deactivated</div>
                   <span v-if="getDemoStatus == 'failed'"> Demo Book generation has failed. Please try again.</span>
                 </div>
@@ -1082,6 +1085,13 @@ export default {
         let langs = _.cloneDeep(this.languages);
         delete langs[this.currentBookMeta.parent_language];
         return langs;
+      },
+      cache: false
+    },
+
+    demoLink: {
+      get() {
+        return this.SERVER_URL + this.currentBook.demo;
       },
       cache: false
     }

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -290,6 +290,7 @@ export const store = new Vuex.Store({
       queue: [],
       running: null,
       log: [],
+      dir: null,
       block: {
         blockId: null,
         partIdx: null,
@@ -4769,12 +4770,16 @@ export const store = new Vuex.Store({
         block: {
           content: content,
           audiosrc: block.getPartAudiosrc(partIdx || 0, false, false),
-          modified: queue[0].modified
+          modified: queue[0].modified,
+          dir: state.audioTasksQueue.dir
         }
       })
         .then((res) => {
           state.audioTasksQueue.queue.splice(0, runSize);
           state.audioTasksQueue.running = null;
+          if (res.data && res.data[0] && res.data[0].dir) {
+            state.audioTasksQueue.dir = res.data[0].dir;
+          }
           let data = [];
           if (Array.isArray(res.data)) {
             data = res.data.filter(r => {
@@ -4836,6 +4841,7 @@ export const store = new Vuex.Store({
         mode: state.bookMode,
         recording_pauses: block.getPartRecordingPauses(alignBlock.partIdx || 0),
         audio_silences: block.getPartAudioSilences(alignBlock.partIdx || 0),
+        dir: state.audioTasksQueue.dir
       };
       if (Array.isArray(state.audioTasksQueue.log)) {
         state.audioTasksQueue.log.filter(l => {
@@ -4860,6 +4866,7 @@ export const store = new Vuex.Store({
       }
       return axios.post(api_url, data, {})
         .then(response => {
+          state.audioTasksQueue.dir = null;
           return new Promise((resolve, reject) => {
             if (realign) {
               return dispatch('getBookAlign')


### PR DESCRIPTION
Releasing tasks and defects
ILM-7448 Move ILM media data on S3 buckets
ILM-7231 Filter tags. Adapted /Translated book. The tags are duplicated (on Production server)
ILM-7443 Book import. The footnote is not imported Into ILM
ILM-7469 Move ILM media data on S3 buckets. Publish. FFA. The illustrations and audio are not published into FFA
ILM-7462 Move ILM media data on S3 buckets. TOC sections. The previously generated M4A and FLAC zip folders are not deleted
ILM-7467 Move ILM media data on S3 buckets. Demobook by link. The illustration is not displayed in the book (except the cover)
ILM-7466 Import the book from Gutenberg. The caption is not imported into ILM
ILM-7460 Move ILM media data on S3 buckets. The demobook is not built/rebuilt
ILM-7461 TOC. The sections are not generated
ILM-7459 Move ILM media data on S3 buckets. HTML popup. The audio file (flac and M4A) can not be downloaded
ILM-7458 Move ILM media data on S3 buckets. The extra folder with audio file is created after joining the two blocks
ILM-7454 Move ILM media data on S3 buckets. The big audio file is not imported
ILM-7445 Book import. The block is duplicated on ILM
ILM-7451 "Create the checklist for the task ""Move ILM media data on S3 buckets"""
ILM-7444 Book import. The text is imported as a part of the paragraph
ILM-7436 Fix import of this book from Gutenberg